### PR TITLE
[Bugfix] Fix hermes tool parser handling of non-string argument types

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
@@ -319,14 +319,14 @@ class Hermes2ProToolParser(ToolParser):
                              cur_arguments_json)
 
                 # get the location where previous args differ from current.
-                #   if the second last character is a quote, the last
-                #   argument is a string, so remove the last two
-                #   characters (quote and brace).
-                #   otherwise, remove the last character (brace)
-                stripped_cur_arguments_json = cur_arguments_json[:-2] \
-                    if (cur_arguments_json[-2] == '"'
-                            or cur_arguments_json[-2] == "'") else \
-                    cur_arguments_json[:-1]
+                if cur_arguments_json[-2] in ('"', "'"):
+                    # last argument is a string,
+                    #   so remove the closing quote and brace.
+                    stripped_cur_arguments_json = cur_arguments_json[:-2]
+                else:
+                    # last argument is not a string,
+                    #   so remove the closing brace only.
+                    stripped_cur_arguments_json = cur_arguments_json[:-1]
                 if (delta_text not in stripped_cur_arguments_json):
                     return None
                 args_delta_start_loc = stripped_cur_arguments_json. \


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose

Fix hermes tool parser handling of non-string argument types.

One example of the situation when argument type is integer is described in https://github.com/vllm-project/vllm/issues/21372.

## Test Plan

Test the issue described in https://github.com/vllm-project/vllm/issues/21372.

Serving command:
```
vllm serve /workspace/models/Qwen3-4B     --reasoning-parser qwen3 --served-model-name 'Qwen/Qwen3-4B' --enable-auto-tool-choice --tool-call-parser Hermes
```

Code:

```Python
import json

from openai import OpenAI

openai_api_key = "EMPTY"
openai_api_base = "http://localhost:8000/v1"

client = OpenAI(
    api_key=openai_api_key,
    base_url=openai_api_base,
)

messages = [
    {
        "role": "system",
        "content": "You are an artificial intelligence assistant who will call tools everytime when responding.",
    },
    {
        "role": "user",
        "content": "Hi! Do you have any detailed information about the product id 7355608?",
    },
]
tools = [
    {
        "type": "function",
        "function": {
            "name": "get_product_info",
            "description": "Get detailed information of a product based on its product ID.",
            "parameters": {
                "type": "object",
                "properties": {
                    "product_id": {
                        "type": "integer",
                        "description": "The product ID of the product.",
                    }
                },
                "required": ["product_id"],
            },
        },
    },
    {
        "type": "function",
        "function": {
            "name": "get_product_id_from_name",
            "description": "Get the identification of a product based on its product name that can be used as the input for tool `get_product_info` to get the detailed description of a specific product.\n`get_product_info` should be called after getting valid response from this tool.",
            "parameters": {
                "type": "object",
                "properties": {
                    "product_name": {
                        "type": "string",
                        "description": "The product name to get the ID from.",
                    }
                },
                "required": ["product_name"],
            },
        },
    },
]
use_stream = True
model = client.models.list().data[0].id
chat_completion = client.chat.completions.create(
    stream=use_stream,
    messages=messages,
    top_p=0.95,
    temperature=0.66,
    presence_penalty=0,
    frequency_penalty=0.04,
    model=model,
    tools=tools,
    extra_body={
        "top_k": 20,
        "repetition_penalty": 1.05,
        "chat_template_kwargs": {"enable_thinking": False},
    },
)
debug_list = list()
if use_stream:
    print("Tool call args:")
    for c in chat_completion:
        if c.choices[0].delta.tool_calls:
            print(c.choices[0].delta.tool_calls[0].function.arguments, end="")
        debug_list.append(c)
else:
    print("Chat completion tool calls:")
    print(chat_completion.choices[0].message.tool_calls)
    print(chat_completion.choices[0].message.tool_calls[0].function. Arguments)
print("\n")
```

## Test Result

```
Tool call args:
None{"product_id": 7355608}
```

